### PR TITLE
Version Bump Dependencies + Add rusttls support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,24 @@
 [package]
 name = "certstreamrs"
 description = "A library for streaming Certificate Transparency Log events from the certstream service"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Andrew Gutekanst <andrew.gutekanst@gmail.com>"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Andoryuuta/certstream-rs"
 readme = "README.md"
 
+[features]
+default = ["native-tls"]
+native-tls = ["tokio-tungstenite/native-tls"]
+rustls-tls-native-roots = ["tokio-tungstenite/rustls-tls-native-roots"]
+rustls-tls-webpki-roots = ["tokio-tungstenite/rustls-tls-webpki-roots"]
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.17.0", features = ["full"] }
-tokio-stream = "0.1.8"
-async-stream = "0.3.3"
-tokio-tungstenite = { version = "0.17.1", features = ["native-tls"] }
-url = "2.2.2"
-futures-util = "0.3.21"
+tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
+async-stream = "0.3"
+tokio-tungstenite = { version = "0.26" }
+futures-util = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,7 @@ impl CertstreamClient {
     }
 
     pub fn watch_certs(&self) -> impl Stream<Item = Result<CertstreamMessage, Box<dyn Error>>> {
-        let url = url::Url::parse(&self.url).unwrap();
-
+        let url = self.url.clone();
         try_stream! {
             loop {
                 // Connect to the certstream websocket server, which provides a constant stream of certificate notifications.


### PR DESCRIPTION
Creating this PR to add rusttls support so that it can be linked without depending on openssl. Currently still leaving the default as native-tls.

Also truncated the minor patch numbers as well as incrementing some deep versions. Let me know what you think.

Btw thanks for building this library, it works pretty well!